### PR TITLE
Update mirror.rb - fix missing signature issue for custom repositories

### DIFF
--- a/lib/rmt/mirror.rb
+++ b/lib/rmt/mirror.rb
@@ -86,8 +86,8 @@ class RMT::Mirror
     local_filename = @downloader.download('repodata/repomd.xml')
 
     begin
-      key_file       = @downloader.download('repodata/repomd.xml.key')
       signature_file = @downloader.download('repodata/repomd.xml.asc')
+      key_file       = @downloader.download('repodata/repomd.xml.key')
 
       RMT::GPG.new(
         metadata_file: local_filename, key_file: key_file, signature_file: signature_file, logger: @logger


### PR DESCRIPTION
Hhange download order for repo metadata files (start with signature, then key) to prevent breaking of custom repostories which don't provide a repomd.xml.key.

The existing code tries to download a repomd.xml.key ; if no sich file is present in the repository, the repomd.xml.asc signature is not downloaded; this renders the whole repository miror useless, because package managemtn tools cannot verify the repository metadata, even if the have the signing key in their keyring.

Example of a repo which gets broken : packages.icinga.com
